### PR TITLE
iOS PageView 백 제스처 이슈 수정

### DIFF
--- a/ios/ReactNativePageView.m
+++ b/ios/ReactNativePageView.m
@@ -134,7 +134,6 @@
         [hoverPanGesture setCancelsTouchesInView:NO];
         [self.scrollView addGestureRecognizer:hoverPanGesture];
     }
-    [self.scrollView setScrollEnabled:YES];
 }
 
 - (void)shouldScroll:(BOOL)scrollEnabled {
@@ -530,7 +529,11 @@
     return YES;
 }
 
-- (void)hoverPanned:(UIPanGestureRecognizer *)sender { }
+- (void)hoverPanned:(UIPanGestureRecognizer *)gestureRecognizer {
+    if (gestureRecognizer.state == UIGestureRecognizerStateEnded) {
+        [self.scrollView setScrollEnabled:YES];
+    }
+}
 
 @end
 


### PR DESCRIPTION
현상: PagerView 좌우 제스처로 인해 백 제스처 미동작
원인: PagerView(iOS: ReactNativePageView)의 컨테이너 ScrollView(iOS: _UIQueueScrollView)의 PanGesture가 우선 시 되어 네비게이션 백 제스처 미동작
해결방법: 원인이 되는 제스처에 네비게이션 백 제스처를 우선하도록 델리게이트 세팅(UIGestureRecognizerDelegate.shouldRecognizeSimultaneouslyWithGestureRecognizer) 및 조건 추가